### PR TITLE
Simpler api

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Check out into `$GOPATH/src/github.com/mergermarket/run-amqp`.
 
 `docker-compose run runamqp`
 
+Specific test
+
+`docker-compose run runamqp go test -run=TestRequeue_DLQ_Message_After_Retries`
+
 There is a test harness app in `sample` so you can play around with it a bit
 
 `docker-compose run --service-ports sampleapp`

--- a/SimpleLogger.go
+++ b/SimpleLogger.go
@@ -5,7 +5,7 @@ import (
 	"io"
 )
 
-// SimpleLogger is a simple implementation of Logger which sends messages to a file
+// SimpleLogger is a simple implementation of Logger which sends messages to an io.Writer
 type SimpleLogger struct {
 	Out io.Writer
 }

--- a/SimpleLogger.go
+++ b/SimpleLogger.go
@@ -12,15 +12,15 @@ type SimpleLogger struct {
 
 // Info writes INFO and messages to stdout
 func (s *SimpleLogger) Info(x ...interface{}) {
-	fmt.Fprintln(s.Out, "INFO  ", x)
+	fmt.Fprintln(s.Out, "INFO", x)
 }
 
 // Error writes ERROR and messages to stdout
 func (s *SimpleLogger) Error(x ...interface{}) {
-	fmt.Fprintln(s.Out, "ERROR ", x)
+	fmt.Fprintln(s.Out, "ERROR", x)
 }
 
 // Debug writes DEBUG and messages to stdout
 func (s *SimpleLogger) Debug(x ...interface{}) {
-	fmt.Fprintln(s.Out, "DEBUG ", x)
+	fmt.Fprintln(s.Out, "DEBUG", x)
 }

--- a/SimpleLogger_test.go
+++ b/SimpleLogger_test.go
@@ -1,0 +1,39 @@
+package runamqp
+
+import (
+	"testing"
+	"bytes"
+)
+
+func TestSimpleLoggerDebug(t *testing.T) {
+	var b bytes.Buffer
+	logger := SimpleLogger{&b}
+
+	t.Run("Debug", func(t *testing.T) {
+		b.Reset()
+		logger.Debug("Hello, world")
+
+		if b.String() != "DEBUG [Hello, world]\n" {
+			t.Error("Unexpected debug output", b.String())
+		}
+	})
+
+	t.Run("Info", func(t *testing.T) {
+		b.Reset()
+		logger.Info("Hello, world")
+
+		if b.String() != "INFO [Hello, world]\n" {
+			t.Error("Unexpected debug output", b.String())
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		b.Reset()
+		logger.Error("Hello, world")
+
+		if b.String() != "ERROR [Hello, world]\n" {
+			t.Error("Unexpected debug output", b.String())
+		}
+	})
+
+}

--- a/SimpleLogger_test.go
+++ b/SimpleLogger_test.go
@@ -1,9 +1,11 @@
 package runamqp
 
 import (
-	"testing"
 	"bytes"
+	"testing"
 )
+
+const testMsg = "Hello, world"
 
 func TestSimpleLoggerDebug(t *testing.T) {
 	var b bytes.Buffer
@@ -11,7 +13,7 @@ func TestSimpleLoggerDebug(t *testing.T) {
 
 	t.Run("Debug", func(t *testing.T) {
 		b.Reset()
-		logger.Debug("Hello, world")
+		logger.Debug(testMsg)
 
 		if b.String() != "DEBUG [Hello, world]\n" {
 			t.Error("Unexpected debug output", b.String())
@@ -20,7 +22,7 @@ func TestSimpleLoggerDebug(t *testing.T) {
 
 	t.Run("Info", func(t *testing.T) {
 		b.Reset()
-		logger.Info("Hello, world")
+		logger.Info(testMsg)
 
 		if b.String() != "INFO [Hello, world]\n" {
 			t.Error("Unexpected debug output", b.String())
@@ -29,7 +31,7 @@ func TestSimpleLoggerDebug(t *testing.T) {
 
 	t.Run("Error", func(t *testing.T) {
 		b.Reset()
-		logger.Error("Hello, world")
+		logger.Error(testMsg)
 
 		if b.String() != "ERROR [Hello, world]\n" {
 			t.Error("Unexpected debug output", b.String())

--- a/StdOutLogger.go
+++ b/StdOutLogger.go
@@ -1,0 +1,26 @@
+package runamqp
+
+import (
+	"fmt"
+	"io"
+)
+
+// SimpleLogger is a simple implementation of Logger which sends messages to a file
+type SimpleLogger struct {
+	Out io.Writer
+}
+
+// Info writes INFO and messages to stdout
+func (s *SimpleLogger) Info(x ...interface{}) {
+	fmt.Fprintln(s.Out, "INFO  ", x)
+}
+
+// Error writes ERROR and messages to stdout
+func (s *SimpleLogger) Error(x ...interface{}) {
+	fmt.Fprintln(s.Out, "ERROR ", x)
+}
+
+// Debug writes DEBUG and messages to stdout
+func (s *SimpleLogger) Debug(x ...interface{}) {
+	fmt.Fprintln(s.Out, "DEBUG ", x)
+}

--- a/config.go
+++ b/config.go
@@ -73,7 +73,7 @@ func NewConsumerConfig(URL string, exchangeName string, exchangeType ExchangeTyp
 		patterns = append(patterns, "#") //testme
 	}
 
-	queueName := fmt.Sprintf("%s-for-%s-queue", exchangeName, serviceName)
+	queueName := fmt.Sprintf("%s-for-%s", exchangeName, serviceName)
 
 	return ConsumerConfig{
 		connection: connection{

--- a/config.go
+++ b/config.go
@@ -66,12 +66,14 @@ func NewPublisherConfig(URL string, exchangeName string, exchangeType ExchangeTy
 }
 
 // NewConsumerConfig config for establishing a RabbitMq consumer
-func NewConsumerConfig(URL string, exchangeName string, exchangeType ExchangeType, queueName string, patterns []string, logger logger, requeueTTL int16, requeueLimit int, serviceName string) ConsumerConfig {
+func NewConsumerConfig(URL string, exchangeName string, exchangeType ExchangeType, patterns []string, logger logger, requeueTTL int16, requeueLimit int, serviceName string) ConsumerConfig {
 
 	if len(patterns) == 0 {
 		logger.Info("Executive decision made! You did not supply a pattern so we have added a default of '#'")
 		patterns = append(patterns, "#") //testme
 	}
+
+	queueName := fmt.Sprintf("%s-for-%s-queue", exchangeName, serviceName)
 
 	return ConsumerConfig{
 		connection: connection{

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ func TestItDerivesConsumerExchanges(t *testing.T) {
 
 	consumerConfig := NewConsumerConfig(
 		testRabbitURI,
-		"exchange",
+		"producer-stuff",
 		Fanout,
 		noPatterns,
 		logger,
@@ -19,31 +19,37 @@ func TestItDerivesConsumerExchanges(t *testing.T) {
 		"service",
 	)
 
-	expectededDLEName := "exchange-for-service-dle"
+	expectedQueueName := "producer-stuff-for-service"
+
+	if consumerConfig.queue.Name != expectedQueueName {
+		t.Error("Expected", expectedQueueName, consumerConfig.queue.Name)
+	}
+
+	expectededDLEName := "producer-stuff-for-service-dle"
 
 	if consumerConfig.exchange.DLE != expectededDLEName {
 		t.Error("Expected", expectededDLEName, "but got", consumerConfig.exchange.DLE)
 	}
 
-	expectedRetryNowExchangeName := "exchange-for-service-retry-now"
+	expectedRetryNowExchangeName := "producer-stuff-for-service-retry-now"
 
 	if consumerConfig.exchange.RetryNow != expectedRetryNowExchangeName {
 		t.Error("Expected", expectedRetryNowExchangeName, "but got", consumerConfig.exchange.RetryNow)
 	}
 
-	expectedRetryLaterExchangeName := "exchange-for-service-retry-200ms-later"
+	expectedRetryLaterExchangeName := "producer-stuff-for-service-retry-200ms-later"
 
 	if consumerConfig.exchange.RetryLater != expectedRetryLaterExchangeName {
 		t.Error("Expected", expectedRetryLaterExchangeName, "but got", expectedRetryLaterExchangeName)
 	}
 
-	expectedDLQName := "exchange-for-service-queue-dlq"
+	expectedDLQName := "producer-stuff-for-service-dlq"
 
 	if consumerConfig.queue.DLQ != expectedDLQName {
 		t.Error("Expected", expectedDLQName, "but got", consumerConfig.queue.DLQ)
 	}
 
-	expectedRetryLaterQueueName := "exchange-for-service-queue-retry-200ms-later"
+	expectedRetryLaterQueueName := "producer-stuff-for-service-retry-200ms-later"
 	if consumerConfig.queue.RetryLater != expectedRetryLaterQueueName {
 		t.Error("Expected", expectedRetryLaterQueueName, "but got", consumerConfig.queue.RetryLater)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -12,7 +12,6 @@ func TestItDerivesConsumerExchanges(t *testing.T) {
 		testRabbitURI,
 		"exchange",
 		Fanout,
-		"queue",
 		noPatterns,
 		logger,
 		200,
@@ -38,13 +37,13 @@ func TestItDerivesConsumerExchanges(t *testing.T) {
 		t.Error("Expected", expectedRetryLaterExchangeName, "but got", expectedRetryLaterExchangeName)
 	}
 
-	expectedDLQName := "queue-dlq"
+	expectedDLQName := "exchange-for-service-queue-dlq"
 
 	if consumerConfig.queue.DLQ != expectedDLQName {
 		t.Error("Expected", expectedDLQName, "but got", consumerConfig.queue.DLQ)
 	}
 
-	expectedRetryLaterQueueName := "queue-retry-200ms-later"
+	expectedRetryLaterQueueName := "exchange-for-service-queue-retry-200ms-later"
 	if consumerConfig.queue.RetryLater != expectedRetryLaterQueueName {
 		t.Error("Expected", expectedRetryLaterQueueName, "but got", consumerConfig.queue.RetryLater)
 	}
@@ -55,7 +54,6 @@ func TestItSetsPatternToHashWhenNoneSupplied(t *testing.T) {
 		testRabbitURI,
 		"exchange",
 		Fanout,
-		"queue",
 		noPatterns,
 		&testLogger{t: t},
 		200,
@@ -78,7 +76,6 @@ func TestItSetsPatternsOnQueue(t *testing.T) {
 		testRabbitURI,
 		"exchange",
 		Fanout,
-		"queue",
 		[]string{pattern},
 		&testLogger{t: t},
 		200,

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -200,9 +200,9 @@ func TestRequeue_DLQ_Message_After_Retries(t *testing.T) {
 		Retries:      oneRetry,
 	})
 
-	dlqConsumer, dlqQueuesReady := newDirectConsumer(dlqConfig)
+	dlqConsumer := NewConsumer(dlqConfig)
 
-	if ok := <-dlqQueuesReady; !ok {
+	if ok := <-dlqConsumer.QueuesBound; !ok {
 		t.Fatal("Didnt bind DLQ")
 	}
 
@@ -249,7 +249,7 @@ func TestRequeue_DLQ_Message_After_Retries(t *testing.T) {
 		t.Fatal("Could not REQUEUE the message for the second time")
 	}
 
-	dlqMessage := <-dlqConsumer
+	dlqMessage := <-dlqConsumer.Messages
 
 	if string(dlqMessage.Body()) != string(payload) {
 		t.Fatal("failed to get dlq'd message")

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -78,7 +78,6 @@ func TestDLQ(t *testing.T) {
 
 	dlqConfig := newTestConsumerConfig(t, consumerConfigOptions{
 		ExchangeName: consumerConfig.exchange.DLE,
-		Queuename:    consumerConfig.queue.DLQ,
 	})
 
 	dlqConsumer, dlqQueuesReady := newDirectConsumer(dlqConfig)
@@ -198,7 +197,6 @@ func TestRequeue_DLQ_Message_After_Retries(t *testing.T) {
 
 	dlqConfig := newTestConsumerConfig(t, consumerConfigOptions{
 		ExchangeName: consumerConfig.exchange.DLE,
-		Queuename:    consumerConfig.queue.DLQ,
 		Retries:      oneRetry,
 	})
 
@@ -382,12 +380,12 @@ func newDirectConsumer(config ConsumerConfig) (<-chan Message, <-chan bool) {
 }
 
 type consumerConfigOptions struct {
-	ExchangeType            ExchangeType
-	Patterns                []string
-	ExchangeName, Queuename string
-	Retries                 int
-	SetNoRetries            bool
-	RequeueTTL              int16
+	ExchangeType ExchangeType
+	Patterns     []string
+	ExchangeName string
+	Retries      int
+	SetNoRetries bool
+	RequeueTTL   int16
 }
 
 func newTestConsumerConfig(t *testing.T, config consumerConfigOptions) ConsumerConfig {
@@ -401,10 +399,6 @@ func newTestConsumerConfig(t *testing.T, config consumerConfigOptions) ConsumerC
 
 	if config.ExchangeName == "" {
 		config.ExchangeName = "test-exchange-" + randomString(5)
-	}
-
-	if config.Queuename == "" {
-		config.Queuename = "test-queue-" + randomString(5)
 	}
 
 	if config.Retries == 0 {
@@ -424,7 +418,6 @@ func newTestConsumerConfig(t *testing.T, config consumerConfigOptions) ConsumerC
 		"amqp://guest:guest@rabbitmq:5672/",
 		config.ExchangeName,
 		config.ExchangeType,
-		config.Queuename,
 		config.Patterns,
 		&testLogger{t: t},
 		config.RequeueTTL,

--- a/example_consumer_test.go
+++ b/example_consumer_test.go
@@ -2,6 +2,7 @@ package runamqp
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"time"
 )
@@ -29,7 +30,7 @@ func ExampleConsumer() {
 		"test-example-exchange",
 		Fanout,
 		noPatterns,
-		&exampleLogger{},
+		&SimpleLogger{ioutil.Discard},
 		testRequeueTTL,
 		testRequeueLimit,
 		serviceName,
@@ -74,9 +75,3 @@ func ExampleConsumer() {
 	fmt.Print(handler.calledWith)
 	// Output: Hello, world
 }
-
-type exampleLogger struct{}
-
-func (e *exampleLogger) Debug(msgs ...interface{}) {}
-func (*exampleLogger) Error(msgs ...interface{})   {}
-func (*exampleLogger) Info(msgs ...interface{})    {}

--- a/example_consumer_test.go
+++ b/example_consumer_test.go
@@ -28,7 +28,6 @@ func ExampleConsumer() {
 		testRabbitURI,
 		"test-example-exchange",
 		Fanout,
-		"test-example-queue",
 		noPatterns,
 		&exampleLogger{},
 		testRequeueTTL,

--- a/sample/app.go
+++ b/sample/app.go
@@ -21,7 +21,6 @@ func main() {
 		"amqp://guest:guest@rabbitmq:5672/",
 		exchangeName,
 		runamqp.Fanout,
-		"test-example-queue",
 		noPatterns,
 		&logger{},
 		500,

--- a/sample/app.go
+++ b/sample/app.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/mergermarket/run-amqp"
 	"log"
 	"net/http"

--- a/sample/app.go
+++ b/sample/app.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mergermarket/run-amqp"
 	"log"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -23,7 +24,7 @@ func main() {
 		exchangeName,
 		runamqp.Fanout,
 		noPatterns,
-		&logger{},
+		&runamqp.SimpleLogger{os.Stdout},
 		requeueTTL,
 		requeueLimit,
 		serviceName,
@@ -62,20 +63,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-type logger struct{}
-
-func (*logger) Info(x ...interface{}) {
-	log.Println(x)
-}
-
-func (*logger) Error(x ...interface{}) {
-	log.Println(x)
-}
-
-func (*logger) Debug(x ...interface{}) {
-	log.Println(x)
 }
 
 type SampleHandler struct {

--- a/sample/app.go
+++ b/sample/app.go
@@ -10,29 +10,31 @@ import (
 
 const numberOfWorkers = 3
 const exchangeName = "producer-messages"
+const requeueTTL = 500
+const requeueLimit = 5
+const serviceName = "sample-app"
+const amqpURL = "amqp://guest:guest@rabbitmq:5672/"
 
 var noPatterns = []string{""}
 
 func main() {
 
-	fmt.Println("Run amqp test bench")
-
 	consumerConfig := runamqp.NewConsumerConfig(
-		"amqp://guest:guest@rabbitmq:5672/",
+		amqpURL,
 		exchangeName,
 		runamqp.Fanout,
 		noPatterns,
 		&logger{},
-		500,
-		5,
-		"sample-app",
+		requeueTTL,
+		requeueLimit,
+		serviceName,
 	)
 
 	consumer := runamqp.NewConsumer(consumerConfig)
 
 	select {
 	case <-consumer.QueuesBound:
-		log.Println("Connected!")
+		log.Println("Waiting for messages")
 	case <-time.After(10 * time.Second):
 		log.Fatal("Timed out waiting to set up rabbit")
 	}
@@ -45,6 +47,7 @@ func main() {
 
 	select {
 	case <-publisher.PublishReady:
+		log.Println("Publisher ready")
 	case <-time.After(10 * time.Second):
 		log.Fatal("Timed out waiting to set up rabbit")
 	}
@@ -53,23 +56,13 @@ func main() {
 	publisher.Publish([]byte("2"), "")
 	publisher.Publish([]byte("3"), "")
 
-	log.Println("Listening on 8080, POST /internal/rabit/entry {some body} to publish to the exchange or GET /internal/rabbit/up to see if rabbit is ready")
+	log.Println("Listening on 8080, POST /entry {some body} to publish to the exchange or GET /up to see if rabbit is ready")
 
-	router := http.NewServeMux()
-	router.Handle("/internal/rabbit/", http.StripPrefix("/internal/rabbit", publisher))
-	router.Handle("/brett", brett{})
-
-	err := http.ListenAndServe(":8080", router)
+	err := http.ListenAndServe(":8080", publisher)
 
 	if err != nil {
 		log.Fatal(err)
 	}
-}
-
-type brett struct{}
-
-func (brett) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprint(w, "hi brett")
 }
 
 type logger struct{}
@@ -95,4 +88,5 @@ func (*SampleHandler) Name() string {
 
 func (*SampleHandler) Handle(msg runamqp.Message) {
 	log.Println("Sample handler got message", string(msg.Body()))
+	msg.Ack()
 }

--- a/sample/app.go
+++ b/sample/app.go
@@ -9,7 +9,7 @@ import (
 )
 
 const numberOfWorkers = 3
-const exchangeName = "test-example-exchange"
+const exchangeName = "producer-messages"
 
 var noPatterns = []string{""}
 


### PR DESCRIPTION
This PR removes queue name from the configuration and instead derives the various queue names from the exchange name and service name which hopefully will make it a bit simpler to use and more consistent naming. 

Please look at config_test.go in particular as that describes the names in full