### PR TITLE
[DONT MERGE THIS YET] Adds a PublishOptions arg to the Publish method (!)

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -33,7 +33,7 @@ func TestConsumerConsumesMessages(t *testing.T) {
 		t.Fatal("Is not ready to publish")
 	}
 
-	err := publisher.Publish(payload, "")
+	err := publisher.Publish(payload, "", PublishOptions{})
 
 	if err != nil {
 		t.Fatal("Error when Publishing the message")
@@ -72,7 +72,7 @@ func TestDLQ(t *testing.T) {
 
 	assertReady(t, dlqConsumer.QueuesBound)
 
-	if err := publisher.Publish(payload, ""); err != nil {
+	if err := publisher.Publish(payload, "", PublishOptions{}); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -116,7 +116,7 @@ func TestRequeue(t *testing.T) {
 
 	assertReady(t, publisher.PublishReady)
 
-	if err := publisher.Publish(payload, "all.notifications.bounced"); err != nil {
+	if err := publisher.Publish(payload, "all.notifications.bounced", PublishOptions{}); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -176,7 +176,7 @@ func TestRequeue_DLQ_Message_After_Retries(t *testing.T) {
 
 	assertReady(t, publisher.PublishReady)
 
-	if err := publisher.Publish(payload, ""); err != nil {
+	if err := publisher.Publish(payload, "", PublishOptions{}); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -241,7 +241,7 @@ func TestRequeue_With_No_Requeue_Limit(t *testing.T) {
 
 	assertReady(t, publisher.PublishReady)
 
-	if err := publisher.Publish(payload, ""); err != nil {
+	if err := publisher.Publish(payload, "", PublishOptions{}); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -277,7 +277,7 @@ func TestPatterns(t *testing.T) {
 
 	gotMessageForPattern := func(msg, pattern string) bool {
 
-		if err := publisher.Publish([]byte(msg), pattern); err != nil {
+		if err := publisher.Publish([]byte(msg), pattern, PublishOptions{}); err != nil {
 			t.Fatal("Error when Publishing the message")
 		}
 

--- a/example_consumer_test.go
+++ b/example_consumer_test.go
@@ -65,7 +65,7 @@ func ExampleConsumer() {
 	}
 
 	// Publish a message
-	if err := publisher.Publish([]byte("Hello, world"), ""); err != nil {
+	if err := publisher.Publish([]byte("Hello, world"), "", PublishOptions{}); err != nil {
 		log.Fatal("Error when Publishing the message")
 	}
 

--- a/publisher-server.go
+++ b/publisher-server.go
@@ -9,7 +9,7 @@ import (
 
 type publisher interface {
 	IsReady() bool
-	Publish(message []byte, pattern string) error
+	Publish(message []byte, pattern string, options PublishOptions) error
 }
 
 type viewModel struct {
@@ -105,7 +105,7 @@ func (p *publisherServer) entry(w http.ResponseWriter, r *http.Request) {
 
 	}
 
-	err := p.publisher.Publish(body, pattern)
+	err := p.publisher.Publish(body, pattern, PublishOptions{})
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/publisher-server_test.go
+++ b/publisher-server_test.go
@@ -14,6 +14,7 @@ type stubPublisher struct {
 	publishCalled            bool
 	publishCalledWithMessage string
 	publishCalleWithPattern  string
+	publishCalledWithOptions PublishOptions
 	err                      error
 }
 
@@ -21,10 +22,11 @@ func (s *stubPublisher) IsReady() bool {
 	return s.ready
 }
 
-func (s *stubPublisher) Publish(message []byte, pattern string) error {
+func (s *stubPublisher) Publish(message []byte, pattern string, options PublishOptions) error {
 	s.publishCalled = true
 	s.publishCalledWithMessage = string(message)
 	s.publishCalleWithPattern = pattern
+	s.publishCalledWithOptions = options
 	return s.err
 }
 

--- a/publisher.go
+++ b/publisher.go
@@ -16,15 +16,21 @@ type Publisher struct {
 	publishReady       bool
 }
 
+// PublishOptions contains opts for when publishing AMQP messages
+type PublishOptions struct {
+	Priority uint8
+}
+
 // Publish will publish a message to the configured exchange
-func (p *Publisher) Publish(msg []byte, pattern string) error {
+func (p *Publisher) Publish(msg []byte, pattern string, options PublishOptions) error {
 	err := p.currentAmqpChannel.Publish(
 		p.config.exchange.Name,
 		pattern,
 		false,
 		false,
 		amqp.Publishing{
-			Body: msg,
+			Body:     msg,
+			Priority: options.Priority,
 		},
 	)
 

--- a/sample/app.go
+++ b/sample/app.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatal("Timed out waiting to set up rabbit")
 	}
 
-	publisher.Publish([]byte("This is the publisher being used to... publish"), "")
+	publisher.Publish([]byte("This is the publisher being used to... publish"), "", runamqp.PublishOptions{})
 
 	log.Println("Listening on 8080, POST /entry {some body} to publish to the exchange or GET /up to see if rabbit is ready")
 


### PR DESCRIPTION
Think this needs a bit of a chat.

DONT MERGE THIS... IT's not yet complete but enough has been done to see the approach before carrying on with better test coverage.

We noticed we aren't able to pass Priority along with our messages when using this library.
This change adds a 3rd param to the Publish method, which we can add any more useful AMQP properties to down the line.

It's a breaking change - but this is a pretty fundamental part of working with Rabbit which up til now we've not needed.  It was inevitable!

**Q. What about the default args when you dont care about priority, won't I end up passing 0?**
A. Turns out we're already passing a 0-value for unspecified rabbit options - since they're already part of the 'Publishing' struct, so behaviour would be unchanged:  https://github.com/mergermarket/run-amqp/blob/master/publisher.go#L26

Ruth also has an alternative - adding a second method, which adds surface area to the public methods in a slightly different way.   I have no real opinion either way but I'm sure others do.

Which one is best....?   FIIIGHT