### PR TITLE
Add send to queue functionality

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -27,7 +27,7 @@ func TestConsumerConsumesMessages(t *testing.T) {
 	consumer1Config := newTestConsumerConfig(t, consumerConfigOptions{})
 	consumer2Config := newTestConsumerConfig(t, consumerConfigOptions{
 		ExchangeName: consumer1Config.exchange.Name,
-		ServiceName: consumer1Config.queue.Name + "-second",
+		ServiceName:  consumer1Config.queue.Name + "-second",
 	})
 
 	publisher := NewPublisher(consumer1Config.NewPublisherConfig())

--- a/publisher.go
+++ b/publisher.go
@@ -10,7 +10,7 @@ import (
 // PublishOptions will enable options being sent with the message
 type PublishOptions struct {
 	// Priority will dictate which messages are processed by the consumers first.  The higher the number, the higher the priority
-	Priority       uint8
+	Priority uint8
 	// PublishToQueue will send the message directly to a specific existing queue and the message will not be routed to any other queue attached to the exchange
 	PublishToQueue string
 }

--- a/publisher.go
+++ b/publisher.go
@@ -7,9 +7,12 @@ import (
 	"net/http"
 )
 
-// PublishOptions will enable options being sen with the message
+// PublishOptions will enable options being sent with the message
 type PublishOptions struct {
-	Priority uint8
+	// Priority will dictate which messages are processed by the consumers first.  The higher the number, the higher the priority
+	Priority       uint8
+	// PublishToQueue will send the message directly to a specific existing queue and the message will not be routed to any other queue attached to the exchange
+	PublishToQueue string
 }
 
 // Publisher provides a means of publishing to an exchange and is a http handler providing endpoints of GET /rabbitup, POST /entry
@@ -29,10 +32,17 @@ func (p *Publisher) Publish(msg []byte, pattern string) error {
 
 // PublishWithOptions will publish a message with additional options
 func (p *Publisher) PublishWithOptions(msg []byte, pattern string, options PublishOptions) error {
+
+	exchangeName := p.config.exchange.Name
+	if options.PublishToQueue != "" {
+		exchangeName = ""
+		pattern = options.PublishToQueue
+	}
+
 	err := p.currentAmqpChannel.Publish(
-		p.config.exchange.Name,
+		exchangeName,
 		pattern,
-		false,
+		true,
 		false,
 		amqp.Publishing{
 			Body:     msg,


### PR DESCRIPTION
Publisher can publish to a specific queue (useful when there are a number of queues attached to an exchange and you want to send test data to one queue).