### PR TITLE
PublishOptions to be a pointer

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -39,7 +39,7 @@ func TestConsumerConsumesMessages(t *testing.T) {
 	consumer2 := NewConsumer(consumer2Config)
 	assertReady(t, consumer2.QueuesBound)
 
-	err := publisher.Publish(payload, PublishOptions{})
+	err := publisher.Publish(payload, nil)
 	if err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
@@ -84,7 +84,7 @@ func TestDLQ(t *testing.T) {
 
 	assertReady(t, dlqConsumer.QueuesBound)
 
-	if err := publisher.Publish(payload, PublishOptions{}); err != nil {
+	if err := publisher.Publish(payload, nil); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -128,7 +128,7 @@ func TestRequeue(t *testing.T) {
 
 	assertReady(t, publisher.PublishReady)
 
-	if err := publisher.Publish(payload, PublishOptions{Pattern: "all.notifications.bounced"}); err != nil {
+	if err := publisher.Publish(payload, &PublishOptions{Pattern: "all.notifications.bounced"}); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -188,7 +188,7 @@ func TestRequeue_DLQ_Message_After_Retries(t *testing.T) {
 
 	assertReady(t, publisher.PublishReady)
 
-	if err := publisher.Publish(payload, PublishOptions{}); err != nil {
+	if err := publisher.Publish(payload, nil); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -253,7 +253,7 @@ func TestRequeue_With_No_Requeue_Limit(t *testing.T) {
 
 	assertReady(t, publisher.PublishReady)
 
-	if err := publisher.Publish(payload, PublishOptions{}); err != nil {
+	if err := publisher.Publish(payload, nil); err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
 
@@ -289,7 +289,7 @@ func TestPatterns(t *testing.T) {
 
 	gotMessageForPattern := func(msg, pattern string) bool {
 
-		if err := publisher.Publish([]byte(msg), PublishOptions{Pattern: pattern}); err != nil {
+		if err := publisher.Publish([]byte(msg), &PublishOptions{Pattern: pattern}); err != nil {
 			t.Fatal("Error when Publishing the message")
 		}
 
@@ -337,7 +337,7 @@ func TestPublishToASpecificQueue(t *testing.T) {
 	consumerForTarget := NewConsumer(consumerConfigForTargettedQueue)
 	assertReady(t, consumerForTarget.QueuesBound)
 
-	err := publisher.Publish(payload, PublishOptions{PublishToQueue: consumerConfigForTargettedQueue.queue.Name})
+	err := publisher.Publish(payload, &PublishOptions{PublishToQueue: consumerConfigForTargettedQueue.queue.Name})
 
 	if err != nil {
 		t.Fatal("Error when Publishing the message")

--- a/example_consumer_test.go
+++ b/example_consumer_test.go
@@ -65,7 +65,7 @@ func ExampleConsumer() {
 	}
 
 	// Publish a message
-	if err := publisher.Publish([]byte("Hello, world"), PublishOptions{}); err != nil {
+	if err := publisher.Publish([]byte("Hello, world"), nil); err != nil {
 		log.Fatal("Error when Publishing the message")
 	}
 

--- a/publisher-server.go
+++ b/publisher-server.go
@@ -10,7 +10,7 @@ import (
 
 type publisher interface {
 	IsReady() bool
-	Publish(message []byte, options PublishOptions) error
+	Publish(message []byte, options *PublishOptions) error
 }
 
 type viewModel struct {
@@ -114,7 +114,9 @@ func (p *publisherServer) entry(w http.ResponseWriter, r *http.Request) {
 		publishToQueue = r.URL.Query().Get("publishToQueue")
 	}
 
-	err := p.publisher.Publish(body, PublishOptions{Priority: priority, Pattern: pattern, PublishToQueue: publishToQueue})
+	options := &PublishOptions{Priority: priority, Pattern: pattern, PublishToQueue: publishToQueue}
+
+	err := p.publisher.Publish(body, options)
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -128,9 +130,9 @@ func (p *publisherServer) rabbitup(w http.ResponseWriter, r *http.Request) {
 	p.logger.Debug(p.exchangeName, "Rabbit up hit")
 	if p.publisher.IsReady() {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "Rabbit is up!")
+		fmt.Fprint(w, "Rabbit is up!")
 	} else {
 		w.WriteHeader(http.StatusServiceUnavailable)
-		fmt.Fprintf(w, "Rabbit did not start up!")
+		fmt.Fprint(w, "Rabbit did not start up!")
 	}
 }

--- a/publisher-server_test.go
+++ b/publisher-server_test.go
@@ -16,7 +16,7 @@ type stubPublisher struct {
 	ready                    bool
 	publishCalled            bool
 	publishCalledWithMessage string
-	publishCalledWithOptions PublishOptions
+	publishCalledWithOptions *PublishOptions
 	err                      error
 }
 
@@ -24,7 +24,7 @@ func (s *stubPublisher) IsReady() bool {
 	return s.ready
 }
 
-func (s *stubPublisher) Publish(message []byte, options PublishOptions) error {
+func (s *stubPublisher) Publish(message []byte, options *PublishOptions) error {
 	s.publishCalled = true
 	s.publishCalledWithMessage = string(message)
 	s.publishCalledWithOptions = options
@@ -183,7 +183,7 @@ func TestPublisherServerEntry_ServeHTTP(t *testing.T) {
 		}
 
 		expectedOptions := PublishOptions{Priority: priority, Pattern: pattern, PublishToQueue: publishToQueue}
-		if publisher.publishCalledWithOptions != expectedOptions {
+		if *publisher.publishCalledWithOptions != expectedOptions {
 			t.Error("publisher.PublishWithOptions should have been called with", expectedOptions, "but it was called with", publisher.publishCalledWithOptions)
 		}
 
@@ -226,7 +226,7 @@ func TestPublisherServerEntry_ServeHTTP(t *testing.T) {
 		}
 
 		expectedOptions := PublishOptions{Priority: priority, Pattern: pattern, PublishToQueue: publishToQueue}
-		if publisher.publishCalledWithOptions != expectedOptions {
+		if *publisher.publishCalledWithOptions != expectedOptions {
 			t.Error("publisher.PublishWithOptions should have been called with", expectedOptions, "but it was called with", publisher.publishCalledWithOptions)
 		}
 

--- a/publisher.go
+++ b/publisher.go
@@ -18,7 +18,7 @@ type PublishOptions struct {
 }
 
 func (p PublishOptions) String() string {
-	return fmt.Sprintf(`Priority: "%d" PublishToQueue: "%s" Pattern "%s"`, p.Priority, p.PublishToQueue, p.Pattern)
+	return fmt.Sprintf(`Priority: "%d" Publish to queue: "%s" Pattern "%s"`, p.Priority, p.PublishToQueue, p.Pattern)
 }
 
 // Publisher provides a means of publishing to an exchange and is a http handler providing endpoints of GET /rabbitup, POST /entry
@@ -74,6 +74,7 @@ func (p *Publisher) Publish(msg []byte, options *PublishOptions) error {
 		message := fmt.Sprintf(`Published "%s"`, string(msg))
 		p.config.Logger.Info(message)
 	}
+
 	return nil
 }
 
@@ -111,9 +112,11 @@ func (p *Publisher) listenForReturnedMessages() {
 	if p.currentAmqpChannel != nil {
 		returnMessage := make(chan amqp.Return)
 		p.currentAmqpChannel.NotifyReturn(returnMessage)
+
 		go func() {
 			for msg := range returnMessage {
-				p.config.Logger.Info(fmt.Sprintf(`a message that was published but returned, ExchangeName: "%s" RoutingKey: "%s" ReplyText: "%s"`, msg.Exchange, msg.RoutingKey, msg.ReplyText))
+				msg := fmt.Sprintf(`A message that was published but returned, Exchange name: "%s" Routing key: "%s" Reply text: "%s"`, msg.Exchange, msg.RoutingKey, msg.ReplyText)
+				p.config.Logger.Info(msg)
 			}
 		}()
 	}

--- a/publisher.go
+++ b/publisher.go
@@ -35,10 +35,19 @@ type Publisher struct {
 func (p *Publisher) Publish(msg []byte, options *PublishOptions) error {
 
 	exchangeName := p.config.exchange.Name
-	pattern := options.Pattern
-	if options.PublishToQueue != "" {
-		exchangeName = ""
-		pattern = options.PublishToQueue
+
+	var pattern string
+	var priority uint8
+
+	if options != nil {
+		pattern = options.Pattern
+
+		if options.PublishToQueue != "" {
+			exchangeName = ""
+			pattern = options.PublishToQueue
+		}
+
+		priority = options.Priority
 	}
 
 	err := p.currentAmqpChannel.Publish(
@@ -48,7 +57,7 @@ func (p *Publisher) Publish(msg []byte, options *PublishOptions) error {
 		false,
 		amqp.Publishing{
 			Body:     msg,
-			Priority: options.Priority,
+			Priority: priority,
 		},
 	)
 

--- a/publisher.go
+++ b/publisher.go
@@ -32,7 +32,7 @@ type Publisher struct {
 }
 
 // Publish will publish a message to an exchange
-func (p *Publisher) Publish(msg []byte, options PublishOptions) error {
+func (p *Publisher) Publish(msg []byte, options *PublishOptions) error {
 
 	exchangeName := p.config.exchange.Name
 	pattern := options.Pattern

--- a/sample/app.go
+++ b/sample/app.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatal("Timed out waiting to set up rabbit")
 	}
 
-	publisher.Publish([]byte("This is the publisher being used to... publish"), runamqp.PublishOptions{})
+	publisher.Publish([]byte("This is the publisher being used to... publish"), nil)
 
 	log.Println("Listening on 8080, POST /entry {some body} to publish to the exchange or GET /up to see if rabbit is ready")
 


### PR DESCRIPTION
I know we talked about this yesterday and that this will be a slight breaking change but i've had time to think about it now. Bear in mind this is all pretty micro-optimisation-y but it's pretty low effort stuff in the end

Old code

`Publish(msg []byte, options PublishOptions)`

useage

`Publish(msg, PublishOptions{Priority: 5})`

## Problems

I _imagine_ most of the time you will use the same options to publish in your app, so your code might look like

```go

options := PublishOptions{whatever}

for job := range jobs {
  //...
  publisher.Publish(msg, options)
}
```

And this works fine but it means every publish call we are taking a _copy_ of the struct and passing it to `Publish`. This is inefficient. 

## When this PR gets merged

The difference to the consumer is negligible, but different.

```go

options := PublishOptions{whatever}

for job := range jobs {
  //...
  publisher.Publish(msg, &options)
}
``` 

You now pass an _address_ of your options, so we no longer copy that object around everywhere, we can just make the one instance and re-use it

If you dont want to supply any options, just send `nil`. 