### PR TITLE
Retry bug

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -113,11 +113,11 @@ func TestDLQ(t *testing.T) {
 func TestRequeue(t *testing.T) {
 	t.Parallel()
 
-	const twoRetries = 2
+	const threeRetries = 3
 	patterns := []string{"*.notifications.bounced", "*.notifications.dropped"}
 	consumerConfig := newTestConsumerConfig(t, consumerConfigOptions{
 		Patterns: patterns,
-		Retries:  twoRetries,
+		Retries:  threeRetries,
 	})
 
 	consumer := NewConsumer(consumerConfig)
@@ -157,10 +157,48 @@ func TestRequeue(t *testing.T) {
 
 	amqpMsg, _ := requeuedMessage.(*amqpMessage)
 
-	if _, found := amqpMsg.delivery.Headers["x-retry-count"]; !found {
+	count, found := amqpMsg.delivery.Headers["x-retry-count"]
+	if !found {
 		t.Fatal("x-retry-count was not set correctly")
 	}
 
+	if count.(int64) != 1 {
+		t.Error("First retry count should be 1 but its", count)
+	}
+
+	if err := requeuedMessage.Requeue("Requeuing message again"); err != nil {
+		t.Fatal("Could not requeue the message again")
+	}
+
+	secondRequeuedMsg := getMessage(t, consumer.Messages)
+	amqpMsg, _ = secondRequeuedMsg.(*amqpMessage)
+
+	count, found = amqpMsg.delivery.Headers["x-retry-count"]
+
+	if !found {
+		t.Fatal("x-retry-count was not set correctly")
+	}
+
+	if count.(int64) != 2 {
+		t.Error("Retry count should be now 2 but its", count)
+	}
+
+	if err := secondRequeuedMsg.Requeue("Requeuing message again"); err != nil {
+		t.Fatal("Could not requeue the message again")
+	}
+
+	thirdRequeuedMsg := getMessage(t, consumer.Messages)
+	amqpMsg, _ = thirdRequeuedMsg.(*amqpMessage)
+
+	count, found = amqpMsg.delivery.Headers["x-retry-count"]
+
+	if !found {
+		t.Fatal("x-retry-count was not set correctly")
+	}
+
+	if count.(int64) != 3 {
+		t.Error("Retry count should be now 3 but its", count)
+	}
 }
 
 func TestRequeue_DLQ_Message_After_Retries(t *testing.T) {

--- a/message.go
+++ b/message.go
@@ -66,7 +66,7 @@ func (m *amqpMessage) Requeue(reason string) error {
 			if temp, ok := headerRetryCount.(int64); ok {
 				retryCount = int(temp) + 1
 			} else {
-				retryCount++
+				return fmt.Errorf("The message %+v retry count could not be parsed correctly, this is probably a bug in run-amqp", m)
 			}
 
 		}

--- a/message.go
+++ b/message.go
@@ -63,8 +63,8 @@ func (m *amqpMessage) Requeue(reason string) error {
 		retryCount := 1
 		if headerRetryCount, found := m.delivery.Headers["x-retry-count"]; found {
 
-			if temp, ok := headerRetryCount.(int); ok {
-				retryCount = temp + 1
+			if temp, ok := headerRetryCount.(int64); ok {
+				retryCount = int(temp) + 1
 			} else {
 				retryCount++
 			}


### PR DESCRIPTION
This is properly heinous

If you are using requeue functionality you *must* upgrade to this version, otherwise it will requeue _FOREVER_. (or at least until the operation you're retrying succeeds).

## The problem

The problem was we were type asserting on the message header into `int` but it's actually `int64`. Our behaviour for when the type assertion fails was to increment, which means it would increment our starting value of 1. 

_This is not error handling!_

## The fix

- I have made it so the tests actually check what the requeue count is
- Obviously fixed the type assertion
- If for some reason the type assertion fails it will return an error