### PR TITLE
Publish fail

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -30,8 +30,7 @@ func TestConsumerConsumesMessages(t *testing.T) {
 		ServiceName:  consumer1Config.queue.Name + "-second",
 	})
 
-	publisher := NewPublisher(consumer1Config.NewPublisherConfig())
-	assertReady(t, publisher.PublishReady)
+	publisher, _ := NewPublisher(consumer1Config.NewPublisherConfig())
 
 	consumer1 := NewConsumer(consumer1Config)
 	assertReady(t, consumer1.QueuesBound)
@@ -76,9 +75,8 @@ func TestPublishAndConsumeFromConfirmChannelMessages(t *testing.T) {
 	config := consumer1Config.NewPublisherConfig()
 	config.confirmable = true
 
-	publisher := NewPublisher(config)
-
-	assertReady(t, publisher.PublishReady)
+	publisher, err := NewPublisher(config)
+	assertNoError(t, err)
 
 	consumer1 := NewConsumer(consumer1Config)
 	assertReady(t, consumer1.QueuesBound)
@@ -86,7 +84,7 @@ func TestPublishAndConsumeFromConfirmChannelMessages(t *testing.T) {
 	consumer2 := NewConsumer(consumer2Config)
 	assertReady(t, consumer2.QueuesBound)
 
-	err := publisher.Publish(payload, nil)
+	err = publisher.Publish(payload, nil)
 	if err != nil {
 		t.Fatal("Error when Publishing the message")
 	}
@@ -119,9 +117,8 @@ func TestDLQ(t *testing.T) {
 
 	assertReady(t, consumer.QueuesBound)
 
-	publisher := NewPublisher(consumerConfig.NewPublisherConfig())
-
-	assertReady(t, publisher.PublishReady)
+	publisher, err := NewPublisher(consumerConfig.NewPublisherConfig())
+	assertNoError(t, err)
 
 	dlqConfig := newTestConsumerConfig(t, consumerConfigOptions{
 		ExchangeName: consumerConfig.exchange.DLE,
@@ -171,9 +168,8 @@ func TestRequeue(t *testing.T) {
 
 	assertReady(t, consumer.QueuesBound)
 
-	publisher := NewPublisher(consumerConfig.NewPublisherConfig())
-
-	assertReady(t, publisher.PublishReady)
+	publisher, err := NewPublisher(consumerConfig.NewPublisherConfig())
+	assertNoError(t, err)
 
 	if err := publisher.Publish(payload, &PublishOptions{Pattern: "all.notifications.bounced"}); err != nil {
 		t.Fatal("Error when Publishing the message")
@@ -239,9 +235,8 @@ func TestRequeue_DLQ_Message_After_Retries(t *testing.T) {
 
 	assertReady(t, dlqConsumer.QueuesBound)
 
-	publisher := NewPublisher(consumerConfig.NewPublisherConfig())
-
-	assertReady(t, publisher.PublishReady)
+	publisher, err := NewPublisher(consumerConfig.NewPublisherConfig())
+	assertNoError(t, err)
 
 	if err := publisher.Publish(payload, nil); err != nil {
 		t.Fatal("Error when Publishing the message")
@@ -304,9 +299,8 @@ func TestRequeue_With_No_Requeue_Limit(t *testing.T) {
 
 	assertReady(t, consumer.QueuesBound)
 
-	publisher := NewPublisher(consumerConfig.NewPublisherConfig())
-
-	assertReady(t, publisher.PublishReady)
+	publisher, err := NewPublisher(consumerConfig.NewPublisherConfig())
+	assertNoError(t, err)
 
 	if err := publisher.Publish(payload, nil); err != nil {
 		t.Fatal("Error when Publishing the message")
@@ -339,8 +333,8 @@ func TestPatterns(t *testing.T) {
 	consumer := NewConsumer(consumerConfig)
 	assertReady(t, consumer.QueuesBound)
 
-	publisher := NewPublisher(consumerConfig.NewPublisherConfig())
-	assertReady(t, publisher.PublishReady)
+	publisher, err := NewPublisher(consumerConfig.NewPublisherConfig())
+	assertNoError(t, err)
 
 	gotMessageForPattern := func(msg, pattern string) bool {
 
@@ -379,8 +373,8 @@ func TestPublishToASpecificQueue(t *testing.T) {
 
 	consumerConfig := newTestConsumerConfig(t, consumerConfigOptions{})
 
-	publisher := NewPublisher(consumerConfig.NewPublisherConfig())
-	assertReady(t, publisher.PublishReady)
+	publisher, err := NewPublisher(consumerConfig.NewPublisherConfig())
+	assertNoError(t, err)
 
 	consumer := NewConsumer(consumerConfig)
 	assertReady(t, consumer.QueuesBound)
@@ -392,7 +386,7 @@ func TestPublishToASpecificQueue(t *testing.T) {
 	consumerForTarget := NewConsumer(consumerConfigForTargettedQueue)
 	assertReady(t, consumerForTarget.QueuesBound)
 
-	err := publisher.Publish(payload, &PublishOptions{PublishToQueue: consumerConfigForTargettedQueue.queue.Name})
+	err = publisher.Publish(payload, &PublishOptions{PublishToQueue: consumerConfigForTargettedQueue.queue.Name})
 
 	if err != nil {
 		t.Fatal("Error when Publishing the message")
@@ -504,5 +498,11 @@ func shouldNotGetMessage(t *testing.T, ch <-chan Message) {
 		t.Fatal("Should not have received the message")
 	case <-time.After(1 * time.Second):
 		t.Log("Mesage was not received")
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/example_consumer_test.go
+++ b/example_consumer_test.go
@@ -55,13 +55,11 @@ func ExampleConsumer() {
 
 	// We can now publish to the same exchange for fun
 	publisherConfig := NewPublisherConfig(config.URL, config.exchange.Name, config.exchange.Type, false, config.Logger)
-	publisher := NewPublisher(publisherConfig)
+	publisher, err := NewPublisher(publisherConfig)
 
 	// Let's check the Publisher is ready too
-	select {
-	case <-publisher.PublishReady:
-	case <-time.After(10 * time.Second):
-		log.Fatal("Timed out waiting to set up rabbit")
+	if err != nil {
+		log.Fatal("Problem making publisher", publisher)
 	}
 
 	// Publish a message

--- a/publisher.go
+++ b/publisher.go
@@ -94,6 +94,7 @@ func (p *Publisher) listenForOpenedAMQPChannel() {
 
 func setupCurrentChannel(p *Publisher, ch *amqp.Channel) {
 	p.currentAmqpChannel = ch
+	makeExchange(ch, p.config.exchange.Name, p.config.exchange.Type)
 	p.listenForReturnedMessages()
 	if p.config.confirmable {
 

--- a/publisher.go
+++ b/publisher.go
@@ -20,6 +20,10 @@ type Publisher struct {
 // Publish will publish a message to an exchange
 func (p *Publisher) Publish(msg []byte, options *PublishOptions) error {
 
+	if !p.publishReady {
+		return fmt.Errorf("unable to publish %s, not ready to publish, try later", string(msg))
+	}
+
 	exchangeName := p.config.exchange.Name
 
 	var pattern string
@@ -105,6 +109,7 @@ func (p *Publisher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (p *Publisher) listenForOpenedAMQPChannel() {
 	connectionManager := connection.NewConnectionManager(p.config.URL, p.config.Logger)
 	for ch := range connectionManager.OpenChannel(p.config.exchange.Name) {
+		p.publishReady = false
 		setupCurrentChannel(p, ch)
 	}
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -3,7 +3,6 @@ package runamqp
 import (
 	"github.com/mergermarket/run-amqp/helpers"
 	"testing"
-	"time"
 )
 
 func TestNakedPublisher(t *testing.T) {
@@ -25,6 +24,4 @@ func TestNakedPublisher(t *testing.T) {
 	if err != nil {
 		t.Error("Should not get an error")
 	}
-
-	time.Sleep(5 * time.Second)
 }

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -1,0 +1,30 @@
+package runamqp
+
+import (
+	"github.com/mergermarket/run-amqp/helpers"
+	"testing"
+	"time"
+)
+
+func TestNakedPublisher(t *testing.T) {
+	t.Parallel()
+
+	expectedExchangeName := "chris-rulz" + randomString(5)
+	config := NewPublisherConfig(testRabbitURI, expectedExchangeName, Fanout, true, helpers.NewTestLogger(t))
+
+	publisher, err := NewPublisher(config)
+
+	if err != nil {
+		t.Fatal("problem creating publisher", err)
+	}
+
+	err = publisher.Publish([]byte("whatever"), nil)
+
+	t.Log("Expecting to make exchange with name", expectedExchangeName)
+
+	if err != nil {
+		t.Error("Should not get an error")
+	}
+
+	time.Sleep(5 * time.Second)
+}

--- a/publisher_test.go
+++ b/publisher_test.go
@@ -19,9 +19,28 @@ func TestNakedPublisher(t *testing.T) {
 
 	err = publisher.Publish([]byte("whatever"), nil)
 
-	t.Log("Expecting to make exchange with name", expectedExchangeName)
+	if err != nil {
+		t.Error("Should not get an error", err)
+	}
+}
+
+func TestNotReadyPublisherErrorsOnPublish(t *testing.T) {
+	t.Parallel()
+
+	expectedExchangeName := "chris-rulz" + randomString(5)
+	config := NewPublisherConfig(testRabbitURI, expectedExchangeName, Fanout, true, helpers.NewTestLogger(t))
+
+	publisher, err := NewPublisher(config)
 
 	if err != nil {
-		t.Error("Should not get an error")
+		t.Fatal("problem creating publisher", err)
+	}
+
+	publisher.publishReady = false
+
+	err = publisher.Publish([]byte("whatever"), nil)
+
+	if err == nil {
+		t.Error("Should get an error")
 	}
 }

--- a/sample/app.go
+++ b/sample/app.go
@@ -43,20 +43,17 @@ func main() {
 
 	consumer.Process(handler, numberOfWorkers)
 
-	publisher := runamqp.NewPublisher(consumerConfig.NewPublisherConfig())
+	publisher, err := runamqp.NewPublisher(consumerConfig.NewPublisherConfig())
 
-	select {
-	case <-publisher.PublishReady:
-		log.Println("Publisher ready")
-	case <-time.After(10 * time.Second):
-		log.Fatal("Timed out waiting to set up rabbit")
+	if err != nil {
+		log.Fatal("Problem making publisher", err)
 	}
 
 	publisher.Publish([]byte("This is the publisher being used to... publish"), nil)
 
 	log.Println("Listening on 8080, POST /entry {some body} to publish to the exchange or GET /up to see if rabbit is ready")
 
-	err := http.ListenAndServe(":8080", publisher)
+	err = http.ListenAndServe(":8080", publisher)
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This PR ensures

- We declare exchange on a publisher. This wasn't previously happening and was sort of happening by fluke because people usually make a corresponding consumer; which _does_ declare the exchange
- Removed `PublishReady` field. This public channel stuff is a bit of an anti-pattern because if we try and push to it and consumers haven't emptied it would result in deadlock. As a result new publisher now blocks until it is ready, or times out if it takes longer than 30 seconds