### PR TITLE
set round-robin

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -103,6 +103,10 @@ func (c *Consumer) isExchangeWithQueueReady(connectionManager connection.Connect
 
 	go func() {
 		for channel := range connectionManager.OpenChannel(description) {
+			if err := channel.Qos(1, 0, true); err != nil {
+				c.config.Logger.Error(fmt.Sprintf("problem setting quality of service when consuming %v", err))
+			}
+
 			err := setUpExchangeWithQueue(channel)
 			if err != nil {
 				c.config.Logger.Error(err)


### PR DESCRIPTION
https://godoc.org/github.com/streadway/amqp#Channel.Qos

> To get round-robin behavior between consumers consuming from the same queue on different connections, set the prefetch count to 1, and the next available message on the server will be delivered to the next available consumer.

Whilst we may want to set a prefetch of different sizes later it seems like this can be a nice non-breaking quick win. 