### PR TITLE
NS-1711: Omit credentials when logging URLs 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.12
 
 RUN go get -u github.com/alecthomas/gometalinter
 RUN go get -u github.com/kardianos/govendor

--- a/build-app.sh
+++ b/build-app.sh
@@ -12,7 +12,9 @@ fi
 
 gometalinter \
     --vendor \
-	--exclude='error return value not checked.*(Close|Log|Print).*\(errcheck\)$' \
+	--exclude='error return value not checked.*(Close|Log|Print|fmt.Fprintln|fmt.Fprintf|fmt.Fprint).*$' \
+	--exclude='struct of size.*$' \
+	--exclude='Errors unhandled.*$' \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
 	--exclude='duplicate of.*_test.go.*\(dupl\)$' \
 	--disable=aligncheck \
@@ -25,4 +27,4 @@ gometalinter \
 	--deadline=80s
 
 go fmt $(go list ./... | grep -v /vendor/)
-go test $(go list ./... | grep -v acceptance-tests ) --cover -timeout 10s
+go test $(go list ./... | grep -v acceptance-tests ) --cover -timeout 25s

--- a/build-app.sh
+++ b/build-app.sh
@@ -14,7 +14,6 @@ gometalinter \
     --vendor \
 	--exclude='error return value not checked.*(Close|Log|Print|fmt.Fprintln|fmt.Fprintf|fmt.Fprint).*$' \
 	--exclude='struct of size.*$' \
-	--exclude='Errors unhandled.*$' \
 	--exclude='.*_test\.go:.*error return value not checked.*\(errcheck\)$' \
 	--exclude='duplicate of.*_test.go.*\(dupl\)$' \
 	--disable=aligncheck \

--- a/connection/server-connection.go
+++ b/connection/server-connection.go
@@ -55,7 +55,7 @@ func (c *sConnection) sendError(err *amqp.Error) {
 // sanitiseURL will remove username and password from URL leaving only Host + Path
 func sanitiseURL(URL string) string {
 	parsedURL, _ := url.Parse(URL)
-	return parsedURL.Host + parsedURL.Path
+	return parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
 }
 
 const takeHeartbeatFromServer = 900 * time.Millisecond // less than 1s uses the server's interval

--- a/connection/server-connection.go
+++ b/connection/server-connection.go
@@ -55,7 +55,14 @@ func (c *sConnection) sendError(err *amqp.Error) {
 // sanitiseURL will remove username and password from URL leaving only Host + Path
 func sanitiseURL(URL string) string {
 	parsedURL, _ := url.Parse(URL)
-	return parsedURL.Scheme + "://" + parsedURL.Host + parsedURL.Path
+	user := strings.Split(parsedURL.User.String(), ":")
+	if len(user) != 2 {
+		return URL
+	}
+	username := user[0]
+	password := user[1]
+	hiddenPassword := strings.Repeat("*", len(password))
+	return parsedURL.Scheme + "://" + username + ":" + hiddenPassword + "@" + parsedURL.Host + parsedURL.Path
 }
 
 const takeHeartbeatFromServer = 900 * time.Millisecond // less than 1s uses the server's interval

--- a/connection/server-connection.go
+++ b/connection/server-connection.go
@@ -55,12 +55,11 @@ func (c *sConnection) sendError(err *amqp.Error) {
 // sanitiseURL will remove username and password from URL leaving only Host + Path
 func sanitiseURL(URL string) string {
 	parsedURL, _ := url.Parse(URL)
-	user := strings.Split(parsedURL.User.String(), ":")
-	if len(user) != 2 {
+	username := parsedURL.User.Username()
+	password, _ := parsedURL.User.Password()
+	if len(password) < 1 {
 		return URL
 	}
-	username := user[0]
-	password := user[1]
 	hiddenPassword := strings.Repeat("*", len(password))
 	return parsedURL.Scheme + "://" + username + ":" + hiddenPassword + "@" + parsedURL.Host + parsedURL.Path
 }

--- a/exchange.go
+++ b/exchange.go
@@ -35,7 +35,7 @@ func NewExchangeType(typ string) (ExchangeType, error) {
 	case "direct":
 		return Direct, nil
 	default:
-		return Unrecognised, fmt.Errorf("Unrecognised exchange type %s", typ)
+		return Unrecognised, fmt.Errorf("unrecognised exchange type %s", typ)
 	}
 }
 
@@ -49,7 +49,7 @@ const (
 func makeExchange(ch *amqp.Channel, exchangeName string, exchangeType ExchangeType) error {
 
 	if exchangeType == Unrecognised {
-		return fmt.Errorf("Unrecognised exchange type, check config")
+		return fmt.Errorf("unrecognised exchange type, check config")
 	}
 
 	return ch.ExchangeDeclare(

--- a/message.go
+++ b/message.go
@@ -68,7 +68,7 @@ func (m *amqpMessage) Requeue(reason string) error {
 			if temp, ok := headerRetryCount.(int64); ok {
 				retryCount = int(temp) + 1
 			} else {
-				return fmt.Errorf("The message %+v retry count could not be parsed correctly, this is probably a bug in run-amqp", m)
+				return fmt.Errorf("the message %+v retry count could not be parsed correctly, this is probably a bug in run-amqp", m)
 			}
 
 		}

--- a/publisher-server.go
+++ b/publisher-server.go
@@ -92,8 +92,7 @@ func (p *publisherServer) entry(w http.ResponseWriter, r *http.Request) {
 
 		pattern = r.Form.Get("pattern")
 		body = []byte(r.Form.Get("message"))
-		priorityUint64, _ := strconv.ParseUint(r.Form.Get("priority"), 10, 8)
-		priority = uint8(priorityUint64)
+		priority = getMessagePriority(p, r.Form.Get("priority"))
 		publishToQueue = r.Form.Get("publishToQueue")
 
 	} else {
@@ -109,8 +108,7 @@ func (p *publisherServer) entry(w http.ResponseWriter, r *http.Request) {
 
 		body = b
 		pattern = r.URL.Query().Get("pattern")
-		priorityUint64, _ := strconv.ParseUint(r.URL.Query().Get("priority"), 10, 8)
-		priority = uint8(priorityUint64)
+		priority = getMessagePriority(p, r.URL.Query().Get("priority"))
 		publishToQueue = r.URL.Query().Get("publishToQueue")
 	}
 
@@ -124,6 +122,15 @@ func (p *publisherServer) entry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fmt.Fprintf(w, "Written body to exchange %s", p.exchangeName)
+}
+
+func getMessagePriority(p *publisherServer, value string) uint8 {
+	priorityUint64, err := strconv.ParseUint(value, 10, 8)
+	if err != nil {
+		p.logger.Error(p.exchangeName, "Failed to get the priority for message")
+		priorityUint64 = 0
+	}
+	return uint8(priorityUint64)
 }
 
 func (p *publisherServer) rabbitup(w http.ResponseWriter, r *http.Request) {

--- a/vendor/github.com/streadway/amqp/LICENSE
+++ b/vendor/github.com/streadway/amqp/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012, Sean Treadway, SoundCloud Ltd.
+Copyright (c) 2012-2019, Sean Treadway, SoundCloud Ltd.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/vendor/github.com/streadway/amqp/README.md
+++ b/vendor/github.com/streadway/amqp/README.md
@@ -13,6 +13,11 @@ Future API changes are unlikely but possible. They will be discussed on [Github
 issues](https://github.com/streadway/amqp/issues) along with any bugs or
 enhancements.
 
+## Supported Go Versions
+
+This library supports two most recent Go release series, currently 1.10 and 1.11.
+
+
 ## Supported RabbitMQ Versions
 
 This project supports RabbitMQ versions starting with `2.0` but primarily tested

--- a/vendor/github.com/streadway/amqp/auth.go
+++ b/vendor/github.com/streadway/amqp/auth.go
@@ -32,6 +32,22 @@ func (auth *PlainAuth) Response() string {
 	return fmt.Sprintf("\000%s\000%s", auth.Username, auth.Password)
 }
 
+// AMQPlainAuth is similar to PlainAuth
+type AMQPlainAuth struct {
+	Username string
+	Password string
+}
+
+// Mechanism returns "AMQPLAIN"
+func (auth *AMQPlainAuth) Mechanism() string {
+	return "AMQPLAIN"
+}
+
+// Response returns the null character delimited encoding for the SASL PLAIN Mechanism.
+func (auth *AMQPlainAuth) Response() string {
+	return fmt.Sprintf("LOGIN:%sPASSWORD:%s", auth.Username, auth.Password)
+}
+
 // Finds the first mechanism preferred by the client that the server supports.
 func pickSASLMechanism(client []Authentication, serverMechanisms []string) (auth Authentication, ok bool) {
 	for _, auth = range client {

--- a/vendor/github.com/streadway/amqp/channel.go
+++ b/vendor/github.com/streadway/amqp/channel.go
@@ -114,7 +114,7 @@ func (ch *Channel) shutdown(e *Error) {
 			ch.errors <- e
 		}
 
-		ch.consumers.closeAll()
+		ch.consumers.close()
 
 		for _, c := range ch.closes {
 			close(c)
@@ -274,8 +274,13 @@ func (ch *Channel) sendOpen(msg message) (err error) {
 func (ch *Channel) dispatch(msg message) {
 	switch m := msg.(type) {
 	case *channelClose:
-		ch.connection.closeChannel(ch, newError(m.ReplyCode, m.ReplyText))
+		// lock before sending connection.close-ok
+		// to avoid unexpected interleaving with basic.publish frames if
+		// publishing is happening concurrently
+		ch.m.Lock()
 		ch.send(&channelCloseOk{})
+		ch.m.Unlock()
+		ch.connection.closeChannel(ch, newError(m.ReplyCode, m.ReplyText))
 
 	case *channelFlow:
 		ch.notifyM.RLock()
@@ -291,7 +296,7 @@ func (ch *Channel) dispatch(msg message) {
 			c <- m.ConsumerTag
 		}
 		ch.notifyM.RUnlock()
-		ch.consumers.close(m.ConsumerTag)
+		ch.consumers.cancel(m.ConsumerTag)
 
 	case *basicReturn:
 		ret := newReturn(*m)
@@ -451,8 +456,8 @@ func (ch *Channel) NotifyClose(c chan *Error) chan *Error {
 
 /*
 NotifyFlow registers a listener for basic.flow methods sent by the server.
-When `true` is sent on one of the listener channels, all publishers should
-pause until a `false` is sent.
+When `false` is sent on one of the listener channels, all publishers should
+pause until a `true` is sent.
 
 The server may ask the producer to pause or restart the flow of Publishings
 sent by on a channel. This is a simple flow-control mechanism that a server can
@@ -619,7 +624,11 @@ started with noAck.
 When global is true, these Qos settings apply to all existing and future
 consumers on all channels on the same connection.  When false, the Channel.Qos
 settings will apply to all existing and future consumers on this channel.
-RabbitMQ does not implement the global flag.
+
+Please see the RabbitMQ Consumer Prefetch documentation for an explanation of
+how the global flag is implemented in RabbitMQ, as it differs from the
+AMQP 0.9.1 specification in that global Qos settings are limited in scope to
+channels, not connections (https://www.rabbitmq.com/consumer-prefetch.html).
 
 To get round-robin behavior between consumers consuming from the same queue on
 different connections, set the prefetch count to 1, and the next available
@@ -674,10 +683,10 @@ func (ch *Channel) Cancel(consumer string, noWait bool) error {
 	}
 
 	if req.wait() {
-		ch.consumers.close(res.ConsumerTag)
+		ch.consumers.cancel(res.ConsumerTag)
 	} else {
 		// Potentially could drop deliveries in flight
-		ch.consumers.close(consumer)
+		ch.consumers.cancel(consumer)
 	}
 
 	return nil
@@ -811,7 +820,7 @@ func (ch *Channel) QueueDeclarePassive(name string, durable, autoDelete, exclusi
 QueueInspect passively declares a queue by name to inspect the current message
 count and consumer count.
 
-Use this method to check how many unacknowledged messages reside in the queue,
+Use this method to check how many messages ready for delivery reside in the queue,
 how many consumers are receiving deliveries, and whether a queue by this
 name already exists.
 
@@ -880,7 +889,7 @@ and exchanges will also be restored on server restart.
 If the binding could not complete, an error will be returned and the channel
 will be closed.
 
-When noWait is true and the queue could not be bound, the channel will be
+When noWait is false and the queue could not be bound, the channel will be
 closed with an error.
 
 */
@@ -1027,11 +1036,14 @@ exception will be raised and the channel will be closed.
 Optional arguments can be provided that have specific semantics for the queue
 or server.
 
-When the channel or connection closes, all delivery chans will also close.
+Inflight messages, limited by Channel.Qos will be buffered until received from
+the returned chan.
 
-Deliveries on the returned chan will be buffered indefinitely. To limit memory
-of this buffer, use the Channel.Qos method to limit the amount of
-unacknowledged/buffered deliveries the server will deliver on this Channel.
+When the Channel or Connection is closed, all buffered and inflight messages will
+be dropped.
+
+When the consumer tag is cancelled, all inflight messages will be delivered until
+the returned chan is closed.
 
 */
 func (ch *Channel) Consume(queue, consumer string, autoAck, exclusive, noLocal, noWait bool, args Table) (<-chan Delivery, error) {
@@ -1063,7 +1075,7 @@ func (ch *Channel) Consume(queue, consumer string, autoAck, exclusive, noLocal, 
 	ch.consumers.add(consumer, deliveries)
 
 	if err := ch.call(req, res); err != nil {
-		ch.consumers.close(consumer)
+		ch.consumers.cancel(consumer)
 		return nil, err
 	}
 
@@ -1435,12 +1447,12 @@ func (ch *Channel) TxRollback() error {
 
 /*
 Flow pauses the delivery of messages to consumers on this channel.  Channels
-are opened with flow control not active, to open a channel with paused
-deliveries immediately call this method with true after calling
+are opened with flow control active, to open a channel with paused
+deliveries immediately call this method with `false` after calling
 Connection.Channel.
 
-When active is true, this method asks the server to temporarily pause deliveries
-until called again with active as false.
+When active is `false`, this method asks the server to temporarily pause deliveries
+until called again with active as `true`.
 
 Channel.Get methods will not be affected by flow control.
 
@@ -1449,7 +1461,7 @@ the number of unacknowledged messages or bytes in flight instead.
 
 The server may also send us flow methods to throttle our publishings.  A well
 behaving publishing client should add a listener with Channel.NotifyFlow and
-pause its publishings when true is sent on that channel.
+pause its publishings when `false` is sent on that channel.
 
 Note: RabbitMQ prefers to use TCP push back to control flow for all channels on
 a connection, so under high volume scenarios, it's wise to open separate
@@ -1533,6 +1545,9 @@ is true.
 See also Delivery.Ack
 */
 func (ch *Channel) Ack(tag uint64, multiple bool) error {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
 	return ch.send(&basicAck{
 		DeliveryTag: tag,
 		Multiple:    multiple,
@@ -1547,6 +1562,9 @@ it must be redelivered or dropped.
 See also Delivery.Nack
 */
 func (ch *Channel) Nack(tag uint64, multiple bool, requeue bool) error {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
 	return ch.send(&basicNack{
 		DeliveryTag: tag,
 		Multiple:    multiple,
@@ -1562,6 +1580,9 @@ multiple messages, reducing the amount of protocol messages to exchange.
 See also Delivery.Reject
 */
 func (ch *Channel) Reject(tag uint64, requeue bool) error {
+	ch.m.Lock()
+	defer ch.m.Unlock()
+
 	return ch.send(&basicReject{
 		DeliveryTag: tag,
 		Requeue:     requeue,

--- a/vendor/github.com/streadway/amqp/connection.go
+++ b/vendor/github.com/streadway/amqp/connection.go
@@ -25,8 +25,10 @@ const (
 	defaultConnectionTimeout = 30 * time.Second
 	defaultProduct           = "https://github.com/streadway/amqp"
 	defaultVersion           = "β"
-	defaultChannelMax        = maxChannelMax
-	defaultLocale            = "en_US"
+	// Safer default that makes channel leaks a lot easier to spot
+	// before they create operational headaches. See https://github.com/rabbitmq/rabbitmq-server/issues/1593.
+	defaultChannelMax = (2 << 10) - 1
+	defaultLocale     = "en_US"
 )
 
 // Config is used in DialConfig and Open to specify the desired tuning
@@ -71,7 +73,7 @@ type Config struct {
 
 // Connection manages the serialization and deserialization of frames from IO
 // and dispatches the frames to the appropriate channel.  All RPC methods and
-// asyncronous Publishing, Delivery, Ack, Nack and Return messages are
+// asynchronous Publishing, Delivery, Ack, Nack and Return messages are
 // multiplexed on this channel.  There must always be active receivers for
 // every asynchronous message on this connection.
 type Connection struct {
@@ -109,21 +111,23 @@ type readDeadliner interface {
 	SetReadDeadline(time.Time) error
 }
 
-// defaultDial establishes a connection when config.Dial is not provided
-func defaultDial(network, addr string) (net.Conn, error) {
-	conn, err := net.DialTimeout(network, addr, defaultConnectionTimeout)
-	if err != nil {
-		return nil, err
-	}
+// DefaultDial establishes a connection when config.Dial is not provided
+func DefaultDial(connectionTimeout time.Duration) func(network, addr string) (net.Conn, error) {
+	return func(network, addr string) (net.Conn, error) {
+		conn, err := net.DialTimeout(network, addr, connectionTimeout)
+		if err != nil {
+			return nil, err
+		}
 
-	// Heartbeating hasn't started yet, don't stall forever on a dead server.
-	// A deadline is set for TLS and AMQP handshaking. After AMQP is established,
-	// the deadline is cleared in openComplete.
-	if err := conn.SetDeadline(time.Now().Add(defaultConnectionTimeout)); err != nil {
-		return nil, err
-	}
+		// Heartbeating hasn't started yet, don't stall forever on a dead server.
+		// A deadline is set for TLS and AMQP handshaking. After AMQP is established,
+		// the deadline is cleared in openComplete.
+		if err := conn.SetDeadline(time.Now().Add(connectionTimeout)); err != nil {
+			return nil, err
+		}
 
-	return conn, nil
+		return conn, nil
+	}
 }
 
 // Dial accepts a string in the AMQP URI format and returns a new Connection
@@ -178,7 +182,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 
 	dialer := config.Dial
 	if dialer == nil {
-		dialer = defaultDial
+		dialer = DefaultDial(defaultConnectionTimeout)
 	}
 
 	conn, err = dialer("tcp", addr)
@@ -199,6 +203,7 @@ func DialConfig(url string, config Config) (*Connection, error) {
 
 		client := tls.Client(conn, config.TLSClientConfig)
 		if err := client.Handshake(); err != nil {
+
 			conn.Close()
 			return nil, err
 		}
@@ -256,7 +261,7 @@ func (c *Connection) ConnectionState() tls.ConnectionState {
 
 /*
 NotifyClose registers a listener for close events either initiated by an error
-accompaning a connection.close method or by a normal shutdown.
+accompanying a connection.close method or by a normal shutdown.
 
 On normal shutdowns, the chan will be closed.
 
@@ -315,7 +320,7 @@ including the underlying io, Channels, Notify listeners and Channel consumers
 will also be closed.
 */
 func (c *Connection) Close() error {
-	if c.isClosed() {
+	if c.IsClosed() {
 		return ErrClosed
 	}
 
@@ -330,7 +335,7 @@ func (c *Connection) Close() error {
 }
 
 func (c *Connection) closeWith(err *Error) error {
-	if c.isClosed() {
+	if c.IsClosed() {
 		return ErrClosed
 	}
 
@@ -344,12 +349,14 @@ func (c *Connection) closeWith(err *Error) error {
 	)
 }
 
-func (c *Connection) isClosed() bool {
+// IsClosed returns true if the connection is marked as closed, otherwise false
+// is returned.
+func (c *Connection) IsClosed() bool {
 	return (atomic.LoadInt32(&c.closed) == 1)
 }
 
 func (c *Connection) send(f frame) error {
-	if c.isClosed() {
+	if c.IsClosed() {
 		return ErrClosed
 	}
 
@@ -589,7 +596,7 @@ func (c *Connection) allocateChannel() (*Channel, error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	if c.isClosed() {
+	if c.IsClosed() {
 		return nil, ErrClosed
 	}
 

--- a/vendor/github.com/streadway/amqp/consumers.go
+++ b/vendor/github.com/streadway/amqp/consumers.go
@@ -6,16 +6,30 @@
 package amqp
 
 import (
-	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 )
 
 var consumerSeq uint64
 
+const consumerTagLengthMax = 0xFF // see writeShortstr
+
 func uniqueConsumerTag() string {
-	return fmt.Sprintf("ctag-%s-%d", os.Args[0], atomic.AddUint64(&consumerSeq, 1))
+	return commandNameBasedUniqueConsumerTag(os.Args[0])
+}
+
+func commandNameBasedUniqueConsumerTag(commandName string) string {
+	tagPrefix := "ctag-"
+	tagInfix := commandName
+	tagSuffix := "-" + strconv.FormatUint(atomic.AddUint64(&consumerSeq, 1), 10)
+
+	if len(tagPrefix)+len(tagInfix)+len(tagSuffix) > consumerTagLengthMax {
+		tagInfix = "streadway/amqp"
+	}
+
+	return tagPrefix + tagInfix + tagSuffix
 }
 
 type consumerBuffers map[string]chan *Delivery
@@ -23,42 +37,48 @@ type consumerBuffers map[string]chan *Delivery
 // Concurrent type that manages the consumerTag ->
 // ingress consumerBuffer mapping
 type consumers struct {
-	sync.Mutex
-	chans consumerBuffers
+	sync.WaitGroup               // one for buffer
+	closed         chan struct{} // signal buffer
+
+	sync.Mutex // protects below
+	chans      consumerBuffers
 }
 
 func makeConsumers() *consumers {
-	return &consumers{chans: make(consumerBuffers)}
+	return &consumers{
+		closed: make(chan struct{}),
+		chans:  make(consumerBuffers),
+	}
 }
 
-func bufferDeliveries(in chan *Delivery, out chan Delivery) {
+func (subs *consumers) buffer(in chan *Delivery, out chan Delivery) {
+	defer close(out)
+	defer subs.Done()
+
+	var inflight = in
 	var queue []*Delivery
-	var queueIn = in
 
 	for delivery := range in {
-		select {
-		case out <- *delivery:
-			// delivered immediately while the consumer chan can receive
-		default:
-			queue = append(queue, delivery)
-		}
+		queue = append(queue, delivery)
 
 		for len(queue) > 0 {
 			select {
-			case out <- *queue[0]:
-				queue = queue[1:]
-			case delivery, open := <-queueIn:
-				if open {
+			case <-subs.closed:
+				// closed before drained, drop in-flight
+				return
+
+			case delivery, consuming := <-inflight:
+				if consuming {
 					queue = append(queue, delivery)
 				} else {
-					// stop receiving to drain the queue
-					queueIn = nil
+					inflight = nil
 				}
+
+			case out <- *queue[0]:
+				queue = queue[1:]
 			}
 		}
 	}
-
-	close(out)
 }
 
 // On key conflict, close the previous channel.
@@ -71,12 +91,13 @@ func (subs *consumers) add(tag string, consumer chan Delivery) {
 	}
 
 	in := make(chan *Delivery)
-	go bufferDeliveries(in, consumer)
-
 	subs.chans[tag] = in
+
+	subs.Add(1)
+	go subs.buffer(in, consumer)
 }
 
-func (subs *consumers) close(tag string) (found bool) {
+func (subs *consumers) cancel(tag string) (found bool) {
 	subs.Lock()
 	defer subs.Unlock()
 
@@ -90,15 +111,18 @@ func (subs *consumers) close(tag string) (found bool) {
 	return found
 }
 
-func (subs *consumers) closeAll() {
+func (subs *consumers) close() {
 	subs.Lock()
 	defer subs.Unlock()
 
-	for _, ch := range subs.chans {
+	close(subs.closed)
+
+	for tag, ch := range subs.chans {
+		delete(subs.chans, tag)
 		close(ch)
 	}
 
-	subs.chans = make(consumerBuffers)
+	subs.Wait()
 }
 
 // Sends a delivery to a the consumer identified by `tag`.

--- a/vendor/github.com/streadway/amqp/delivery.go
+++ b/vendor/github.com/streadway/amqp/delivery.go
@@ -36,7 +36,7 @@ type Delivery struct {
 	DeliveryMode    uint8     // queue implementation use - non-persistent (1) or persistent (2)
 	Priority        uint8     // queue implementation use - 0 to 9
 	CorrelationId   string    // application use - correlation identifier
-	ReplyTo         string    // application use - address to to reply to (ex: RPC)
+	ReplyTo         string    // application use - address to reply to (ex: RPC)
 	Expiration      string    // implementation use - message expiration spec
 	MessageId       string    // application use - message identifier
 	Timestamp       time.Time // application use - message timestamp
@@ -52,7 +52,7 @@ type Delivery struct {
 
 	DeliveryTag uint64
 	Redelivered bool
-	Exchange    string // basic.publish exhange
+	Exchange    string // basic.publish exchange
 	RoutingKey  string // basic.publish routing key
 
 	Body []byte

--- a/vendor/github.com/streadway/amqp/go.mod
+++ b/vendor/github.com/streadway/amqp/go.mod
@@ -1,0 +1,3 @@
+module github.com/streadway/amqp
+
+go 1.10

--- a/vendor/github.com/streadway/amqp/pre-commit
+++ b/vendor/github.com/streadway/amqp/pre-commit
@@ -1,29 +1,67 @@
 #!/bin/sh
 
-GOFMT_FILES=$(gofmt -l .)
-if [ -n "${GOFMT_FILES}" ]; then
-  printf >&2 'gofmt failed for the following files:\n%s\n\nplease run "gofmt -w ." on your changes before committing.\n' "${GOFMT_FILES}"
-  exit 1
-fi
+LATEST_STABLE_SUPPORTED_GO_VERSION="1.11"
 
-GOLINT_ERRORS=$(golint ./... | grep -v "Id should be")
-if [ -n "${GOLINT_ERRORS}" ]; then
-  printf >&2 'golint failed for the following reasons:\n%s\n\nplease run 'golint ./...' on your changes before committing.\n' "${GOLINT_ERRORS}"
-  exit 1
-fi
+main() {
+  if local_go_version_is_latest_stable
+  then
+    run_gofmt
+    run_golint
+    run_govet
+  fi
+  run_unit_tests
+}
 
-GOVET_ERRORS=$(go tool vet *.go 2>&1)
-if [ -n "${GOVET_ERRORS}" ]; then
-  printf >&2 'go vet failed for the following reasons:\n%s\n\nplease run "go tool vet *.go" on your changes before committing.\n' "${GOVET_ERRORS}"
-  exit 1
-fi
+local_go_version_is_latest_stable() {
+  go version | grep -q $LATEST_STABLE_SUPPORTED_GO_VERSION
+}
 
-if [ -z "${NOTEST}" ]; then
-  printf >&2 'Running short tests...\n'
-  env AMQP_URL= go test -short -v | egrep 'PASS|ok'
+log_error() {
+  echo "$*" 1>&2
+}
 
-  if [ $? -ne 0 ]; then
-    printf >&2 'go test failed, please fix before committing.\n'
+run_gofmt() {
+  GOFMT_FILES=$(gofmt -l .)
+  if [ -n "$GOFMT_FILES" ]
+  then
+    log_error "gofmt failed for the following files:
+$GOFMT_FILES
+
+please run 'gofmt -w .' on your changes before committing."
     exit 1
   fi
-fi
+}
+
+run_golint() {
+  GOLINT_ERRORS=$(golint ./... | grep -v "Id should be")
+  if [ -n "$GOLINT_ERRORS" ]
+  then
+    log_error "golint failed for the following reasons:
+$GOLINT_ERRORS
+
+please run 'golint ./...' on your changes before committing."
+    exit 1
+  fi
+}
+
+run_govet() {
+  GOVET_ERRORS=$(go tool vet ./*.go 2>&1)
+  if [ -n "$GOVET_ERRORS" ]
+  then
+    log_error "go vet failed for the following reasons:
+$GOVET_ERRORS
+
+please run 'go tool vet ./*.go' on your changes before committing."
+    exit 1
+  fi
+}
+
+run_unit_tests() {
+  if [ -z "$NOTEST" ]
+  then
+    log_error 'Running short tests...'
+    env AMQP_URL= go test -short
+  fi
+}
+
+main

--- a/vendor/github.com/streadway/amqp/types.go
+++ b/vendor/github.com/streadway/amqp/types.go
@@ -200,6 +200,7 @@ type Decimal struct {
 //   byte
 //   float32
 //   float64
+//   int
 //   int16
 //   int32
 //   int64
@@ -225,7 +226,7 @@ type Table map[string]interface{}
 
 func validateField(f interface{}) error {
 	switch fv := f.(type) {
-	case nil, bool, byte, int16, int32, int64, float32, float64, string, []byte, Decimal, time.Time:
+	case nil, bool, byte, int, int16, int32, int64, float32, float64, string, []byte, Decimal, time.Time:
 		return nil
 
 	case []interface{}:

--- a/vendor/github.com/streadway/amqp/uri.go
+++ b/vendor/github.com/streadway/amqp/uri.go
@@ -7,7 +7,7 @@ package amqp
 
 import (
 	"errors"
-	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 	"strings"
@@ -72,7 +72,8 @@ func ParseURI(uri string) (URI, error) {
 		return builder, errURIScheme
 	}
 
-	host, port := splitHostPort(u.Host)
+	host := u.Hostname()
+	port := u.Port()
 
 	if host != "" {
 		builder.Host = host
@@ -115,29 +116,6 @@ func ParseURI(uri string) (URI, error) {
 	return builder, nil
 }
 
-// Splits host:port, host, [ho:st]:port, or [ho:st].  Unlike net.SplitHostPort
-// which splits :port, host:port or [host]:port
-//
-// Handles hosts that have colons that are in brackets like [::1]:http
-func splitHostPort(addr string) (host, port string) {
-	i := strings.LastIndex(addr, ":")
-
-	if i >= 0 {
-		host, port = addr[:i], addr[i+1:]
-
-		if len(port) > 0 && port[len(port)-1] == ']' && addr[0] == '[' {
-			// we've split on an inner colon, the port was missing outside of the
-			// brackets so use the full addr.  We could assert that host should not
-			// contain any colons here
-			host, port = addr, ""
-		}
-	} else {
-		host = addr
-	}
-
-	return
-}
-
 // PlainAuth returns a PlainAuth structure based on the parsed URI's
 // Username and Password fields.
 func (uri URI) PlainAuth() *PlainAuth {
@@ -147,29 +125,52 @@ func (uri URI) PlainAuth() *PlainAuth {
 	}
 }
 
+// AMQPlainAuth returns a PlainAuth structure based on the parsed URI's
+// Username and Password fields.
+func (uri URI) AMQPlainAuth() *AMQPlainAuth {
+	return &AMQPlainAuth{
+		Username: uri.Username,
+		Password: uri.Password,
+	}
+}
+
 func (uri URI) String() string {
-	var authority string
+	authority, err := url.Parse("")
+	if err != nil {
+		return err.Error()
+	}
+
+	authority.Scheme = uri.Scheme
 
 	if uri.Username != defaultURI.Username || uri.Password != defaultURI.Password {
-		authority += uri.Username
+		authority.User = url.User(uri.Username)
 
 		if uri.Password != defaultURI.Password {
-			authority += ":" + uri.Password
+			authority.User = url.UserPassword(uri.Username, uri.Password)
 		}
-
-		authority += "@"
 	}
 
-	authority += uri.Host
+	authority.Host = net.JoinHostPort(uri.Host, strconv.Itoa(uri.Port))
 
 	if defaultPort, found := schemePorts[uri.Scheme]; !found || defaultPort != uri.Port {
-		authority += ":" + strconv.FormatInt(int64(uri.Port), 10)
+		authority.Host = net.JoinHostPort(uri.Host, strconv.Itoa(uri.Port))
+	} else {
+		// JoinHostPort() automatically add brackets to the host if it's
+		// an IPv6 address.
+		//
+		// If not port is specified, JoinHostPort() return an IP address in the
+		// form of "[::1]:", so we use TrimSuffix() to remove the extra ":".
+		authority.Host = strings.TrimSuffix(net.JoinHostPort(uri.Host, ""), ":")
 	}
 
-	var vhost string
 	if uri.Vhost != defaultURI.Vhost {
-		vhost = uri.Vhost
+		// Make sure net/url does not double escape, e.g.
+		// "%2F" does not become "%252F".
+		authority.Path = uri.Vhost
+		authority.RawPath = url.QueryEscape(uri.Vhost)
+	} else {
+		authority.Path = "/"
 	}
 
-	return fmt.Sprintf("%s://%s/%s", uri.Scheme, authority, url.QueryEscape(vhost))
+	return authority.String()
 }

--- a/vendor/github.com/streadway/amqp/write.go
+++ b/vendor/github.com/streadway/amqp/write.go
@@ -308,6 +308,11 @@ func writeField(w io.Writer, value interface{}) (err error) {
 		binary.BigEndian.PutUint16(buf[1:3], uint16(v))
 		enc = buf[:3]
 
+	case int:
+		buf[0] = 'I'
+		binary.BigEndian.PutUint32(buf[1:5], uint32(v))
+		enc = buf[:5]
+
 	case int32:
 		buf[0] = 'I'
 		binary.BigEndian.PutUint32(buf[1:5], uint32(v))

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "T3MxQOn0MmHJ2bxjBzSvGMEjJ/U=",
+			"checksumSHA1": "M9Vpq0g1nLqfEjll3PNZ/yz8gZY=",
 			"path": "github.com/streadway/amqp",
-			"revision": "27859d32540aebd2e5befa52dc59ae8e6a0132b6",
-			"revisionTime": "2017-06-11T16:03:33Z"
+			"revision": "75d898a42a940fbc854dfd1a4199eabdc00cf024",
+			"revisionTime": "2019-04-04T07:53:20Z"
 		},
 		{
 			"checksumSHA1": "8fD/im5Kwvy3JgmxulDTambmE8w=",


### PR DESCRIPTION
**In this PR:**
- Upgrade `golang` to 1.12
- Suppress new linter warnings
- Omit credentials when logging URLs